### PR TITLE
[WIP] Add json logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
   oereb-db:
     build: test-db
     image: camptocamp/oereb-db-dev
+    # Uncomment following line to have database show all incoming SQL statements
+    #command: postgres -c log_statement=all
+
 
   oereb-server:
     networks:

--- a/docker/production.ini
+++ b/docker/production.ini
@@ -36,7 +36,7 @@ reload = true
 ###
 
 [loggers]
-keys = root, pyramid_oereb, sqlalchemy
+keys = root, pyramid_oereb, sqlalchemy, json
 
 [handlers]
 keys = console
@@ -52,6 +52,12 @@ handlers = console
 level = WARN
 handlers =
 qualname = pyramid_oereb
+
+[logger_json]
+level = INFO
+handlers = console
+qualname = JSON
+propagate = 0
 
 [logger_sqlalchemy]
 level = WARN

--- a/pyramid_oereb/contrib/stats/decorators.py
+++ b/pyramid_oereb/contrib/stats/decorators.py
@@ -19,6 +19,7 @@ def _serialize_response(response):
     x = {}
     x['status']=response.status
     x['headers']=dict(response.headers)
+    x['extras']= response.extras if hasattr(response,'extras') else None
     return {'response': x}
 
 def _serialize_request(request):
@@ -31,18 +32,27 @@ def _serialize_request(request):
     return {'request': x}
 
 
-class OerebStats(object):
-    stats={}
-    def __init__(self,
+class OerebStats(dict):
+    def __init__(self, 
                  service=None,
                  output_format=None,
                  location=None,
                  flavour=None):
-           self.stats['service']=service
-           self.stats['output_format']=output_format
-           self.stats['location']=location
-           self.stats['flavour']=flavour
-
-    def __repr__(self):
-         json.dumps(self.stats)
-
+        super(OerebStats,self).__init__(service=service,
+                                        output_format=output_format,
+                                        location=location,
+                                        flavour=flavour)
+        self.itemlist = super(OerebStats,self).keys()
+    def __setitem__(self, key, value):
+         # TODO: what should happen to the order if
+         #       the key is already in the dict       
+        self.itemlist.append(key)
+        super(OerebStats,self).__setitem__(key, value)
+    def __iter__(self):
+        return iter(self.itemlist)
+    def keys(self):
+        return self.itemlist
+    def values(self):
+        return [self[key] for key in self]  
+    def itervalues(self):
+        return (self[key] for key in self)

--- a/pyramid_oereb/contrib/stats/decorators.py
+++ b/pyramid_oereb/contrib/stats/decorators.py
@@ -36,12 +36,10 @@ class OerebStats(dict):
     def __init__(self, 
                  service=None,
                  output_format=None,
-                 location=None,
-                 flavour=None):
+                 params=None):
         super(OerebStats,self).__init__(service=service,
                                         output_format=output_format,
-                                        location=location,
-                                        flavour=flavour)
+                                        params=params)
         self.itemlist = super(OerebStats,self).keys()
     def __setitem__(self, key, value):
          # TODO: what should happen to the order if

--- a/pyramid_oereb/contrib/stats/decorators.py
+++ b/pyramid_oereb/contrib/stats/decorators.py
@@ -1,0 +1,48 @@
+
+import logging
+import json
+
+log = logging.getLogger('JSON')
+
+def log_response(wrapped):
+    def wrapper(context, request):
+        response = wrapped(context, request)
+#        import ipdb; ipdb.set_trace()
+        ret_dict = _serialize_response(response)
+        ret_dict.update(_serialize_request(request))
+        log.info(json.dumps(ret_dict))
+        return response
+    return wrapper
+
+
+def _serialize_response(response):
+    x = {}
+    x['status']=response.status
+    x['headers']=dict(response.headers)
+    return {'response': x}
+
+def _serialize_request(request):
+    x = {}
+    x['headers']=dict(request.headers)
+    x['traversed']=str(request.traversed)
+    x['parameters']=dict(request.GET)
+    x['path']=str(request.path)
+    x['view_name']=str(request.view_name)
+    return {'request': x}
+
+
+class OerebStats(object):
+    stats={}
+    def __init__(self,
+                 service=None,
+                 output_format=None,
+                 location=None,
+                 flavour=None):
+           self.stats['service']=service
+           self.stats['output_format']=output_format
+           self.stats['location']=location
+           self.stats['flavour']=flavour
+
+    def __repr__(self):
+         json.dumps(self.stats)
+

--- a/pyramid_oereb/lib/adapter.py
+++ b/pyramid_oereb/lib/adapter.py
@@ -29,7 +29,7 @@ class DatabaseAdapter(object):
                 connection
         """
         if connection_string not in self._connections_:
-            engine = create_engine(connection_string)
+            engine = create_engine(connection_string, pool_recycle=30)
             session = orm.scoped_session(orm.sessionmaker(bind=engine))
             self._connections_[connection_string] = {
                 'engine': engine,

--- a/pyramid_oereb/routes.py
+++ b/pyramid_oereb/routes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from pyramid_oereb import route_prefix
-from pyramid_oereb.views.webservice import PlrWebservice, Symbol, Logo, Municipality, Sld, not_found
+from pyramid_oereb.views.webservice import PlrWebservice, Symbol, Logo, Municipality, Sld #, not_found
 from pyramid_oereb.contrib.stats.decorators import log_response
 
 
@@ -245,7 +245,7 @@ def includeme(config):  # pragma: no cover
         decorator=log_response
     )
 
-    config.add_notfound_view(not_found, decorator = log_response)
+#    config.add_notfound_view(not_found, decorator = log_response)
     
     # Commit config
     config.commit()

--- a/pyramid_oereb/routes.py
+++ b/pyramid_oereb/routes.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 from pyramid_oereb import route_prefix
-from pyramid_oereb.views.webservice import PlrWebservice, Symbol, Logo, Municipality, Sld
+from pyramid_oereb.views.webservice import PlrWebservice, Symbol, Logo, Municipality, Sld, not_found
 from pyramid_oereb.contrib.stats.decorators import log_response
+
 
 
 def includeme(config):  # pragma: no cover
@@ -244,5 +245,7 @@ def includeme(config):  # pragma: no cover
         decorator=log_response
     )
 
+    config.add_notfound_view(not_found, decorator = log_response)
+    
     # Commit config
     config.commit()

--- a/pyramid_oereb/routes.py
+++ b/pyramid_oereb/routes.py
@@ -245,7 +245,10 @@ def includeme(config):  # pragma: no cover
         decorator=log_response
     )
 
-#    config.add_notfound_view(not_found, decorator = log_response)
+    config.add_notfound_view(
+        PlrWebservice,
+        attr='not_found',
+        decorator = log_response)
     
     # Commit config
     config.commit()

--- a/pyramid_oereb/routes.py
+++ b/pyramid_oereb/routes.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from pyramid_oereb import route_prefix
 from pyramid_oereb.views.webservice import PlrWebservice, Symbol, Logo, Municipality, Sld
+from pyramid_oereb.contrib.stats.decorators import log_response
 
 
 def includeme(config):  # pragma: no cover
@@ -14,23 +15,23 @@ def includeme(config):  # pragma: no cover
     # Service for logo images
     config.add_route('{0}/image/logo'.format(route_prefix), '/image/logo/{logo}/{language}.{extension}')
     config.add_view(Logo, attr='get_image', route_name='{0}/image/logo'.format(route_prefix),
-                    request_method='GET')
+                    request_method='GET', decorator=log_response)
 
     # Service for municipality images
     config.add_route('{0}/image/municipality'.format(route_prefix), '/image/municipality/{fosnr}.{extension}')
     config.add_view(Municipality, attr='get_image', route_name='{0}/image/municipality'.format(route_prefix),
-                    request_method='GET')
+                    request_method='GET', decorator=log_response)
 
     # Service for symbol images
     config.add_route('{0}/image/symbol'.format(route_prefix),
                      '/image/symbol/{theme_code}/{view_service_id}/{type_code}.{extension}')
     config.add_view(Symbol, attr='get_image', route_name='{0}/image/symbol'.format(route_prefix),
-                    request_method='GET')
+                    request_method='GET', decorator=log_response)
 
     # Service for sld creation on egrid input
     config.add_route('{0}/sld'.format(route_prefix), '/sld')
     config.add_view(Sld, attr='get_sld', route_name='{0}/sld'.format(route_prefix),
-                    request_method='GET')
+                    request_method='GET', decorator=log_response)
 
     # Get versions
     config.add_route('{0}/versions/'.format(route_prefix), '/versions/{format}')
@@ -38,7 +39,8 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_versions',
         route_name='{0}/versions/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
 
     # Get version - Can be removed if backward compatibility no longer required.
@@ -47,21 +49,24 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_versions',
         route_name='{0}/versions.json'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_route('{0}/versions'.format(route_prefix), '/versions')
     config.add_view(
         PlrWebservice,
         attr='get_versions',
         route_name='{0}/versions'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_route('{0}/versions_old/'.format(route_prefix), '/versions/')
     config.add_view(
         PlrWebservice,
         attr='get_versions',
         route_name='{0}/versions_old/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
 
     # Get capabilities
@@ -70,7 +75,8 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_capabilities',
         route_name='{0}/capabilities/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
 
     # Get capabilities - Can be removed if backward compatibility no longer required.
@@ -79,21 +85,24 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_capabilities',
         route_name='{0}/capabilities.json'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_route('{0}/capabilities'.format(route_prefix), '/capabilities')
     config.add_view(
         PlrWebservice,
         attr='get_capabilities',
         route_name='{0}/capabilities'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_route('{0}/capabilities_old'.format(route_prefix), '/capabilities/')
     config.add_view(
         PlrWebservice,
         attr='get_capabilities',
         route_name='{0}/capabilities_old'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
 
     # Get egrid
@@ -105,19 +114,22 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_egrid_coord',
         route_name='{0}/getegrid_coord/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_egrid_ident',
         route_name='{0}/getegrid_ident/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_egrid_address',
         route_name='{0}/getegrid_address/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
 
     # Get egrid - Can be removed if backward compatibility no longer required.
@@ -129,19 +141,22 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_egrid_coord',
         route_name='{0}/getegrid_coord.json'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_egrid_ident',
         route_name='{0}/getegrid_ident.json'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_egrid_address',
         route_name='{0}/getegrid_address.json'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_route('{0}/getegrid_coord'.format(route_prefix), '/getegrid')
     config.add_route('{0}/getegrid_ident'.format(route_prefix), '/getegrid/{identdn}/{number}')
@@ -153,13 +168,15 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_egrid_coord',
         route_name='{0}/getegrid_coord'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_egrid_ident',
         route_name='{0}/getegrid_ident'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
 
     config.add_route('{0}/getegrid_coord_old/'.format(route_prefix), '/getegrid/')
@@ -167,7 +184,8 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_egrid_coord',
         route_name='{0}/getegrid_coord_old/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
 
     # Get extract by id
@@ -181,19 +199,22 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_extract_by_id',
         route_name='{0}/extract_1'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_extract_by_id',
         route_name='{0}/extract_2'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_extract_by_id',
         route_name='{0}/extract_3'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_route('{0}/extract_1/'.format(route_prefix),
                      '/extract/{flavour}/{format}/{param1}/')
@@ -205,19 +226,22 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_extract_by_id',
         route_name='{0}/extract_1/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_extract_by_id',
         route_name='{0}/extract_2/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_extract_by_id',
         route_name='{0}/extract_3/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
 
     # Commit config

--- a/pyramid_oereb/standard/sources/plr.py
+++ b/pyramid_oereb/standard/sources/plr.py
@@ -365,6 +365,10 @@ class DatabaseSource(BaseDatabaseSource, PlrBaseSource):
     def get_document_records(self, public_law_restriction_from_db):
         documents_from_db = []
         article_numbers = []
+        if not hasattr(public_law_restriction_from_db, 'legal_provisions'):
+            raise AttributeError('The public_law_restriction implementation of type {} has no '
+                                 'legal_provisions attribute. Check the model implementation.'
+                                 .format(type(public_law_restriction_from_db)))
         for legal_provision in public_law_restriction_from_db.legal_provisions:
             documents_from_db.append(legal_provision.document)
             article_nrs = legal_provision.article_numbers.split('|') if legal_provision.article_numbers \

--- a/pyramid_oereb/views/webservice.py
+++ b/pyramid_oereb/views/webservice.py
@@ -17,6 +17,8 @@ from pyreproj import Reprojector
 from pyramid_oereb.lib.readers.address import AddressReader
 from timeit import default_timer as timer
 
+from pyramid_oereb.contrib.stats.decorators import OerebStats
+
 log = logging.getLogger(__name__)
 
 
@@ -86,6 +88,7 @@ class PlrWebservice(object):
         response = render_to_response(renderer_name, versions, request=self._request)
         if self._is_json():
             response.content_type = 'application/json; charset=UTF-8'
+        response.extras = OerebStats(service='GetVersions', output_format=renderer_name)
         return response
 
     def get_capabilities(self):
@@ -130,6 +133,7 @@ class PlrWebservice(object):
         response = render_to_response(renderer_name, capabilities, request=self._request)
         if self._is_json():
             response.content_type = 'application/json; charset=UTF-8'
+        response.extras = OerebStats(service='GetCapabilities', output_format=renderer_name)
         return response
 
     def get_egrid_coord(self):
@@ -250,6 +254,7 @@ class PlrWebservice(object):
                 raise HTTPBadRequest("The format '{}' is wrong".format(params.format))
             end_time = timer()
             log.debug("DONE with extract, time spent: {} seconds".format(end_time - start_time))
+            response.extras = OerebStats(service='GetExtractById', output_format=params.format)
             return response
         else:
             return HTTPNoContent("No real estate found")
@@ -401,6 +406,7 @@ class PlrWebservice(object):
         response = render_to_response(renderer_name, egrid, request=self._request)
         if self._is_json():
             response.content_type = 'application/json; charset=UTF-8'
+        response.extras=OerebStats(service='GetEGRID', output_format=renderer_name, location=egrid)
         return response
 
     def __parse_xy__(self, xy, buffer_dist=None):

--- a/pyramid_oereb/views/webservice.py
+++ b/pyramid_oereb/views/webservice.py
@@ -22,9 +22,9 @@ from pyramid_oereb.contrib.stats.decorators import OerebStats
 log = logging.getLogger(__name__)
 
 
-
-def not_found(request):
-    return Response('Not Found', status='404 Not Found')
+#
+#def not_found(request):
+#    return Response('Not Found', status='404 Not Found')
 
 
 class PlrWebservice(object):
@@ -155,7 +155,7 @@ class PlrWebservice(object):
             records = self._real_estate_reader.read(**{'geometry': geom_wkt})
             return self.__get_egrid_response__(records)
         else:
-            raise HTTPBadRequest('XY or GNSS must be defined.')
+            return HTTPBadRequest('XY or GNSS must be defined.')
 
     def get_egrid_ident(self):
         """
@@ -173,7 +173,7 @@ class PlrWebservice(object):
             })
             return self.__get_egrid_response__(records)
         else:
-            raise HTTPBadRequest('IDENTDN and NUMBER must be defined.')
+            return HTTPBadRequest('IDENTDN and NUMBER must be defined.')
 
     def get_egrid_address(self):
         """
@@ -197,7 +197,7 @@ class PlrWebservice(object):
             records = self._real_estate_reader.read(**{'geometry': geometry})
             return self.__get_egrid_response__(records)
         else:
-            raise HTTPBadRequest('POSTALCODE, LOCALISATION and NUMBER must be defined.')
+            return HTTPBadRequest('POSTALCODE, LOCALISATION and NUMBER must be defined.')
 
     def get_extract_by_id(self):
         """
@@ -220,7 +220,7 @@ class PlrWebservice(object):
                 number=params.number
             )
         else:
-            raise HTTPBadRequest("Missing required argument")
+            return HTTPBadRequest("Missing required argument")
 
         # check if result is strictly one (we queried with primary keys)
         if len(real_estate_records) == 1:

--- a/pyramid_oereb/views/webservice.py
+++ b/pyramid_oereb/views/webservice.py
@@ -22,9 +22,6 @@ from pyramid_oereb.contrib.stats.decorators import OerebStats
 log = logging.getLogger(__name__)
 
 
-#
-#def not_found(request):
-#    return Response('Not Found', status='404 Not Found')
 
 
 class PlrWebservice(object):
@@ -52,6 +49,9 @@ class PlrWebservice(object):
         """
         url = self._request.current_route_url().split('?')
         return url[0].endswith('.json')
+
+    def not_found(request):
+        return Response('Not Found', status='404 Not Found')
 
     def get_versions(self):
         """

--- a/pyramid_oereb/views/webservice.py
+++ b/pyramid_oereb/views/webservice.py
@@ -20,6 +20,11 @@ from timeit import default_timer as timer
 log = logging.getLogger(__name__)
 
 
+
+def not_found(request):
+    return Response('Not Found', status='404 Not Found')
+
+
 class PlrWebservice(object):
     """
     This class provides the PLR webservice methods.

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ zope.sqlalchemy==1.2
 jsonschema==3.2.0
 pyproj==1.9.6  # rq.filter: <2.0.0
 pyreproj==1.0.1 # rq.filter: <2.0.0
-lxml==4.4.1
+lxml==4.4.2
 requests==2.22.0
 geolink-formatter==1.4.0
 pyconizer==0.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,6 @@ lxml==4.4.1
 requests==2.22.0
 geolink-formatter==1.4.0
 pyconizer==0.1.4
-tqdm==4.38.0
+tqdm==4.39.0
 numpy==1.16.5  # rq.filter: <1.17.0
 defusedxml==0.6.0

--- a/test-db/Dockerfile
+++ b/test-db/Dockerfile
@@ -1,4 +1,4 @@
-FROM camptocamp/postgres:9.5
+FROM camptocamp/postgres:10
 
 LABEL maintainer Camptocamp "info@camptocamp.com"
 


### PR DESCRIPTION
This PR adds a custom json logger that can be used to output a pyramid application log as json string.

A custom `extras` field is added to the Response object, and a custom `OerebStats(dict)` is used to map the Oereb application business logic.

The msg string of the log will contains something similar to :
 ```json
{
  "response": {
    "status": "200 OK",
    "headers": {
      "Content-Type": "application/json; charset=UTF-8",
      "Content-Length": "36386"
    },
    "extras": {
      "service": "GetExtractById",
      "output_format": "json",
      "location": null,
      "flavour": null
    }
  },
  "request": {
    "headers": {
      "Host": "localhost:6543",
      "User-Agent": "curl/7.58.0",
      "Accept": "*/*"
    },
    "traversed": "()",
    "parameters": {},
    "path": "/oereb/extract/embeddable/json/CH113928077734",
    "view_name": ""
  }
}

```

[WIP]
- Currently all 4 services are mapped, but for none of them the `flavour` or `location` is defined  
- I have to check how to decorate the renderer `not-found` and `no-content` instead of overwriting the `not-found` view as I did at the end of `views.py`. I did this like this for the moment to test a decorated 404.